### PR TITLE
Postioner cache

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,14 +7,14 @@ interval:
   fetch: 2
   websocket: 5
 lap_source:
-  id: 5
+  id: 8
   name: robust-lapper
 position_source:
-  id: 1
+  id: 6
   name: nostradamus
 site:
   freeze: null
-  message: test-message
+  message: null
 telraam:
-  api: http://localhost:8080
-  ws: ws://localhost:8080/ws
+  api: http://host.docker.internal:8080
+  ws: ws://host.docker.internal:8080/ws

--- a/config.yml
+++ b/config.yml
@@ -7,14 +7,14 @@ interval:
   fetch: 2
   websocket: 5
 lap_source:
-  id: 8
+  id: 5
   name: robust-lapper
 position_source:
-  id: 6
+  id: 1
   name: nostradamus
 site:
   freeze: null
   message: null
 telraam:
-  api: http://host.docker.internal:8080
-  ws: ws://host.docker.internal:8080/ws
+  api: http://localhost:8080
+  ws: ws://localhost:8080/ws

--- a/src/data_publisher.py
+++ b/src/data_publisher.py
@@ -118,7 +118,7 @@ class DataPublisher(QueueManager):
                     )
 
                 if position_source == self._settings.position_source.name:
-                    await self._broadcast((topic, data))
+                    await self._broadcast((topic, data["positions"]))
                 return
 
             if topic in self._cache and self._cache[topic] == data:

--- a/src/data_publisher.py
+++ b/src/data_publisher.py
@@ -1,6 +1,8 @@
 from asyncio import Lock, Queue
 from typing import Any
 
+from src.settings import Settings
+
 JsonData = str | int | float | dict | list
 
 
@@ -60,8 +62,9 @@ class DataPublisher(QueueManager):
     Also provides a way to publish data to topics. This way one queue can easily be used for multiple data updates.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, settings: Settings) -> None:
         super().__init__()
+        self._settings = settings
         self._cache: dict[str, Any] = dict()
         self._cache["position"] = {}
         self._publish_lock: Lock = Lock()
@@ -81,7 +84,17 @@ class DataPublisher(QueueManager):
             for topic in self._cache:
                 if topic != "position":
                     await queue.put((topic, self._cache[topic]))
-            position_data = [self._cache["position"][team_id] for team_id in self._cache["position"]]
+
+            position_data = []
+            if self._settings.position_source.name in self._cache["position"]:
+                position_data = [
+                    self._cache["position"][self._settings.position_source.name][
+                        team_id
+                    ]
+                    for team_id in self._cache["position"][
+                        self._settings.position_source.name
+                    ]
+                ]
             await queue.put(("position", position_data))
         return queue
 
@@ -95,9 +108,17 @@ class DataPublisher(QueueManager):
         """
         async with self._publish_lock:
             if topic == "position":
-                for team_data in data:
-                    self._cache[topic][team_data["team_id"]] = team_data
-                await self._broadcast((topic, data))
+                position_source = data["positioner"]
+                if position_source not in self._cache[topic]:
+                    self._cache[topic][position_source] = {}
+
+                for team_data in data["positions"]:
+                    self._cache[topic][position_source][team_data["team_id"]] = (
+                        team_data
+                    )
+
+                if position_source == self._settings.position_source.name:
+                    await self._broadcast((topic, data))
                 return
 
             if topic in self._cache and self._cache[topic] == data:

--- a/src/dependecies.py
+++ b/src/dependecies.py
@@ -6,8 +6,8 @@ from src.websocket import WebSocketHandler, ConnectionTracker
 
 _settings = Settings.load_from_yaml("config.yml")
 
-_feed_publisher = DataPublisher()
-_admin_publisher = DataPublisher()
+_feed_publisher = DataPublisher(_settings)
+_admin_publisher = DataPublisher(_settings)
 
 _connection_tracker = ConnectionTracker(_admin_publisher)
 

--- a/src/routes.py
+++ b/src/routes.py
@@ -47,6 +47,7 @@ async def _post_lap_source(
     lap_source_id: int,
     settings: Annotated[Settings, Depends(get_settings)],
     admin_publisher: Annotated[DataPublisher, Depends(get_admin_publisher)],
+    feed_publisher: Annotated[DataPublisher, Depends(get_feed_publisher)],
 ):
     try:
         lap_sources: list[dict]
@@ -67,6 +68,8 @@ async def _post_lap_source(
             raise HTTPException(
                 status_code=HTTP_409_CONFLICT, detail="Invalid LapSource Id"
             )
+
+        await feed_publisher.publish("refresh", True)
         return ["ok"]
     except httpx.ConnectError:
         await admin_publisher.publish("telraam-health", "bad")
@@ -80,6 +83,7 @@ async def _post_position_source(
     position_source_id: int,
     settings: Annotated[Settings, Depends(get_settings)],
     admin_publisher: Annotated[DataPublisher, Depends(get_admin_publisher)],
+    feed_publisher: Annotated[DataPublisher, Depends(get_feed_publisher)],
 ):
     try:
         position_sources: list[dict]
@@ -102,6 +106,7 @@ async def _post_position_source(
             raise HTTPException(
                 status_code=HTTP_409_CONFLICT, detail="Invalid PositionSource Id"
             )
+        await feed_publisher.publish("refresh", True)
         return ["ok"]
     except httpx.ConnectError:
         await admin_publisher.publish("telraam-health", "bad")

--- a/src/tasks/listener.py
+++ b/src/tasks/listener.py
@@ -54,20 +54,15 @@ class WebSocketListener:
         if "topic" not in data or "data" not in data:
             raise ValueError("Invalid message from telraam")
 
-        # Only let messages from the selected position source through
         if data["topic"] == "position":
             position_data = data["data"]
-            if position_data == None:
+            if position_data is None:
                 return
+
             if "positioner" not in position_data or "positions" not in position_data:
                 raise ValueError("Invalid message from telraam")
 
-            if position_data["positioner"] != self._settings.position_source.name:
-                return
-
-            await self._feed_publisher.publish(
-                data["topic"], position_data["positions"]
-            )
+            await self._feed_publisher.publish(data["topic"], position_data)
             return
 
         await self._feed_publisher.publish(data["topic"], data["data"])


### PR DESCRIPTION
- Keep a cache for each positioner allowing for instant transitions (instead of only showing a difference when new data comes in)
- Force reload all clients when we switch to a new lapper or positioner